### PR TITLE
Fix kbo organization sameas override

### DIFF
--- a/app.js
+++ b/app.js
@@ -49,6 +49,7 @@ app.post("/sync-kbo-data/:kboStructuredIdUuid", async (req, res) => {
     );
 
     await createOrUpdateOvoStructure(
+      abbOrganizationInfo.abbOrgUri,
       kboFields.ovoNumber,
       abbOrganizationInfo.ovo,
       abbOrganizationInfo.kboStructuredIdUri,
@@ -117,12 +118,14 @@ const createOrUpdateKboOrg = async (abbOrgUri, kboIdentifierUri, kboFields) => {
 
 /**
  * Create or update the OVO structure
+ * @param {string} abbOrgUri - The ABB organization URI
  * @param {string} wegwijsOvo - The OVO number from Wegwijs
  * @param {string} abbOvo - The OVO number from ABB
  * @param {string} kboStructuredIdUri - The KBO structured ID URI
  * @param {string} ovoStructuredIdUri - The OVO structured ID URI
  */
 const createOrUpdateOvoStructure = async (
+  abbOrgUri,
   wegwijsOvo,
   abbOvo,
   kboStructuredIdUri,
@@ -132,9 +135,9 @@ const createOrUpdateOvoStructure = async (
   // It happens especially a lot for worship services that sometimes lack data in Wegwijs.
   if (wegwijsOvo && wegwijsOvo != abbOvo) {
     if (!ovoStructuredIdUri) {
-      ovoStructuredIdUri = await createOvoStructure(kboStructuredIdUri);
+      ovoStructuredIdUri = await createOvoStructure(abbOrgUri, kboStructuredIdUri);
     }
-    await updateOvoNumberAndUri(ovoStructuredIdUri, wegwijsOvo);
+    await updateOvoNumberAndUri(abbOrgUri, ovoStructuredIdUri, wegwijsOvo);
   }
 };
 
@@ -157,6 +160,7 @@ async function healAbbWithWegWijsData() {
         );
 
         await createOrUpdateOvoStructure(
+          abbOrganizationInfo.abbOrgUri,
           wegwijsKboFields.ovoNumber,
           abbOrganizationInfo.ovo,
           abbOrganizationInfo.kboStructuredIdUri,

--- a/lib/queries.js
+++ b/lib/queries.js
@@ -387,6 +387,56 @@ export const buildContactPointQuery = (
 };
 
 /**
+ * Build the query to create a new KBO identifier.
+ * @param {string} kboIdentifierUri The URI of the KBO identifier.
+ * @param {string} kboIdentifierUuid The UUID of the KBO identifier.
+ * @param {string} abbOrgKboIdentifierUri The KBO identifier URI linked to abbOrgUri.
+ * @param {string} kboNumber The KBO number.
+ * @returns {string} The query to create a new KBO identifier.
+ */
+export const buildKboIdentifierQuery = (
+  kboIdentifierUri,
+  kboIdentifierUuid,
+  abbOrgKboIdentifierUri,
+  kboNumber
+) => {
+  const kboStructuredIdentifierUuid = uuid();
+  const kboStructuredIdentifierUri = `http://data.lblod.info/id/gestructureerdeIdentificator/${kboStructuredIdentifierUuid}`;
+
+  let kboIdentifierStr = `${sparqlEscapeUri(
+    kboStructuredIdentifierUri
+  )} a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+      <http://mu.semte.ch/vocabularies/core/uuid> ${sparqlEscapeString(
+        kboStructuredIdentifierUuid
+      )} ;
+      <http://purl.org/dc/terms/source> <https://economie.fgov.be/> ;
+      <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> ${sparqlEscapeString(
+        kboNumber
+      )} . 
+  
+    ${sparqlEscapeUri(
+      kboIdentifierUri
+    )} a <http://www.w3.org/ns/adms#Identifier> ;
+      <http://mu.semte.ch/vocabularies/core/uuid> ${sparqlEscapeString(
+        kboIdentifierUuid
+      )} ;
+      <http://purl.org/dc/terms/source> <https://economie.fgov.be/> ;
+      <http://www.w3.org/2004/02/skos/core#notation> """KBO nummer""" ;
+      <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator> ${sparqlEscapeUri(
+        kboStructuredIdentifierUri
+      )} `;
+
+  if (abbOrgKboIdentifierUri) {
+    kboIdentifierStr += `;
+      <http://www.w3.org/2002/07/owl#sameAs> ${sparqlEscapeUri(
+        abbOrgKboIdentifierUri
+      )}`;
+  }
+
+  return `${kboIdentifierStr} .`;
+};
+
+/**
  * Build the query to create a new KBO organization.
  * @param {string} kboOrgUri The URI of the KBO organization.
  * @param {string} kboOrgUuid The UUID of the KBO organization.
@@ -456,11 +506,15 @@ export const buildKboOrgQuery = (
 /**
  * Create a new KBO organization and its related address and contact point.
  * @param {import('../typedefs').KboFields} kboFields The fields of the KBO organization.
- * @param {string} kboIdentifierUri The KBO identifier URI.
+ * @param {string} abbOrgKboIdentifierUri The KBO identifier URI linked to abbOrgUri.
  * @param {string} abbOrgUri The ABB organization URI.
  * @returns {Promise<string>} The URI of the new KBO organization.
  */
-export const createKboOrg = async (kboFields, kboIdentifierUri, abbOrgUri) => {
+export const createKboOrg = async (
+  kboFields,
+  abbOrgKboIdentifierUri,
+  abbOrgUri
+) => {
   const addressUuid = uuid();
   const addressUri = `http://data.lblod.info/id/adressen/${addressUuid}`;
   const addressQuery = buildKboAddressQuery(
@@ -476,6 +530,15 @@ export const createKboOrg = async (kboFields, kboIdentifierUri, abbOrgUri) => {
     contactPointUuid,
     addressUri,
     kboFields
+  );
+
+  const kboIdentifierUuid = uuid();
+  const kboIdentifierUri = `http://data.lblod.info/id/identificatoren/${kboIdentifierUuid}`;
+  const kboIdentifierQuery = buildKboIdentifierQuery(
+    kboIdentifierUri,
+    kboIdentifierUuid,
+    abbOrgKboIdentifierUri,
+    kboFields.kboNumber
   );
 
   const kboOrgUuid = uuid();
@@ -496,16 +559,20 @@ export const createKboOrg = async (kboFields, kboIdentifierUri, abbOrgUri) => {
 
         ${contactPointQuery}
 
+        ${kboIdentifierQuery}
+
         ${kboOrgQuery}
       }
   } WHERE {
     VALUES ?g { ${graphValues} }
     GRAPH ?g {
-      ?organization <http://www.w3.org/ns/adms#identifier> ${sparqlEscapeUri(
-        kboIdentifierUri
-      )} 
+      ?abbOrg <http://www.w3.org/ns/adms#identifier> ${sparqlEscapeUri(
+        abbOrgKboIdentifierUri
+      )}
+
+      FILTER(?abbOrg = ${sparqlEscapeUri(abbOrgUri)})
     }
-  }   
+  } 
   `;
 
   await update(updateStr);

--- a/lib/queries.js
+++ b/lib/queries.js
@@ -253,7 +253,7 @@ export async function updateOvoNumberAndUri(ovoStructuredIdUri, wegwijsOvo) {
  */
 export async function getAllAbbKboOrganizations() {
   let queryStr = `
-   SELECT ?kbo ?ovo ?kboStructuredId ?ovoStructuredId ?abbOrg ?kboOrg ?kboId ?kboOrgModified WHERE {
+   SELECT DISTINCT ?kbo ?ovo ?kboStructuredId ?ovoStructuredId ?abbOrg ?kboOrg ?kboId ?kboOrgModified WHERE {
        VALUES ?g { ${graphValues} }
        GRAPH ?g {
          ?kboId <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator> ?kboStructuredId ;

--- a/lib/queries.js
+++ b/lib/queries.js
@@ -261,7 +261,7 @@ export async function updateOvoNumberAndUri(
  */
 export async function getAllAbbKboOrganizations() {
   let queryStr = `
-   SELECT DISTINCT ?kbo ?ovo ?kboStructuredId ?ovoStructuredId ?abbOrg ?kboOrg ?kboId ?kboOrgModified WHERE {
+   SELECT ?kbo ?ovo ?kboStructuredId ?ovoStructuredId ?abbOrg ?kboOrg ?kboId ?kboOrgModified WHERE {
        VALUES ?g { ${graphValues} }
        GRAPH ?g {
          ?kboId <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator> ?kboStructuredId ;
@@ -291,7 +291,7 @@ export async function getAllAbbKboOrganizations() {
           FILTER (?ovoNotation IN ("OVO-nummer"@nl, "OVO-nummer"))
         }
        }
-     }
+     } GROUP BY ?abbOrg
    `;
 
   const { results } = await query(queryStr);

--- a/lib/queries.js
+++ b/lib/queries.js
@@ -38,6 +38,7 @@ export async function getAbbOrganizationInfo(kboStructuredIdUuid) {
         ?organization <http://www.w3.org/ns/adms#identifier> ?kboId .
 
         FILTER (?kboNotation IN ("KBO nummer"@nl, "KBO nummer"))
+        FILTER (!regex(?organization, "kboOrganisaties","i"))
 
         OPTIONAL {
           ?organization <http://www.w3.org/ns/adms#identifier> ?ovoId .
@@ -75,7 +76,7 @@ export async function getAbbOrganizationInfo(kboStructuredIdUuid) {
  * @typedef {object} KboOrganizationInfo
  * @property {string} [kboOrgUri] The URI of the KBO organization.
  * @property {string} [abbOrgUri] The URI of the ABB organization.
- * @property {string} [modified] The change time in wegwijs. 
+ * @property {string} [modified] The change time in wegwijs.
  * @property {string} [contactPointUri] The URI of the contact point.
  * @property {string} [addressUri] The URI of the address.
  *
@@ -123,10 +124,11 @@ export async function getKboOrganizationInfo(abbOrganization) {
 
 /**
  * Create a new OVO structured identifier for the given KBO structured identifier.
+ * @param {string} abbOrgUri The URI of the ABB organization.
  * @param {string} kboStructuredId The URI of the KBO structured identifier.
  * @returns {Promise<string>} The URI of the new OVO structured identifier.
  */
-export async function createOvoStructure(kboStructuredId) {
+export async function createOvoStructure(abbOrgUri, kboStructuredId) {
   const idUuid = uuid();
   const idUri = `http://data.lblod.info/id/identificatoren/${idUuid}`;
   const structuredIdUuid = uuid();
@@ -135,7 +137,7 @@ export async function createOvoStructure(kboStructuredId) {
   const updateStr = `
     INSERT {
       GRAPH ?g {
-        ?organization <http://www.w3.org/ns/adms#identifier> ${sparqlEscapeUri(
+        ?abbOrg <http://www.w3.org/ns/adms#identifier> ${sparqlEscapeUri(
           idUri
         )} .
 
@@ -168,23 +170,28 @@ export async function createOvoStructure(kboStructuredId) {
         )} ;
           <http://www.w3.org/2004/02/skos/core#notation> ?notation .
 
-        ?organization <http://www.w3.org/ns/adms#identifier> ?kboId .
+        ?abbOrg <http://www.w3.org/ns/adms#identifier> ?kboId .
 
         FILTER (?notation IN ("KBO nummer"@nl, "KBO nummer"))
+        FILTER(?abbOrg = ${sparqlEscapeUri(abbOrgUri)})
       }
     }
   `;
 
   await update(updateStr);
-  
+
   return structuredIdUri;
 }
 
-export async function updateOvoNumberAndUri(ovoStructuredIdUri, wegwijsOvo) {
+export async function updateOvoNumberAndUri(
+  abbOrgUri,
+  ovoStructuredIdUri,
+  wegwijsOvo
+) {
   let updateStr = `
     DELETE {
       GRAPH ?g {
-        ?bestuureseenheid <http://www.w3.org/2002/07/owl#sameAs> ?ovoUri .
+        ?abbOrg <http://www.w3.org/2002/07/owl#sameAs> ?ovoUri .
         ${sparqlEscapeUri(
           ovoStructuredIdUri
         )} <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> ?ovo .
@@ -196,7 +203,7 @@ export async function updateOvoNumberAndUri(ovoStructuredIdUri, wegwijsOvo) {
     updateStr += `
       INSERT {
         GRAPH ?g {
-          ?bestuureseenheid <http://www.w3.org/2002/07/owl#sameAs> ${sparqlEscapeUri(
+          ?abbOrg <http://www.w3.org/2002/07/owl#sameAs> ${sparqlEscapeUri(
             `http://data.vlaanderen.be/id/organisatie/${wegwijsOvo}`
           )} .
           ${sparqlEscapeUri(
@@ -219,8 +226,7 @@ export async function updateOvoNumberAndUri(ovoStructuredIdUri, wegwijsOvo) {
         )} a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> .
 
         OPTIONAL {
-          ?bestuureseenheid
-          <http://www.w3.org/ns/adms#identifier>/<https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator> ${sparqlEscapeUri(
+          ?abbOrg <http://www.w3.org/ns/adms#identifier>/<https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator> ${sparqlEscapeUri(
             ovoStructuredIdUri
           )} ;
           <http://www.w3.org/2002/07/owl#sameAs> ?ovoUri .
@@ -229,6 +235,8 @@ export async function updateOvoNumberAndUri(ovoStructuredIdUri, wegwijsOvo) {
         OPTIONAL { ${sparqlEscapeUri(
           ovoStructuredIdUri
         )} <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> ?ovo . }
+
+        FILTER(?abbOrg = ${sparqlEscapeUri(abbOrgUri)})
       }
     }
   `;

--- a/test/lib/queries.data.js
+++ b/test/lib/queries.data.js
@@ -30,6 +30,20 @@ export const buildContactPointQueryDefault = `
     <http://www.w3.org/ns/locn#address> <http://addressUri> .
 `;
 
+export const buildKboIdentifierQueryFull = `
+<http://data.lblod.info/id/gestructureerdeIdentificator/1234567890> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+  <http://mu.semte.ch/vocabularies/core/uuid> """1234567890""" ;
+  <http://purl.org/dc/terms/source> <https://economie.fgov.be/> ;
+  <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> """0207437468""" . 
+
+<http://kboIdentifierUri> a <http://www.w3.org/ns/adms#Identifier> ;
+  <http://mu.semte.ch/vocabularies/core/uuid> """kboIdentifierUuid""" ;
+  <http://purl.org/dc/terms/source> <https://economie.fgov.be/> ;
+  <http://www.w3.org/2004/02/skos/core#notation> """KBO nummer""" ;
+  <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator> <http://data.lblod.info/id/gestructureerdeIdentificator/1234567890> ; 
+  <http://www.w3.org/2002/07/owl#sameAs> <http://abbOrgKboIdentifierUri> .
+`;
+
 export const buildKboOrgQueryFull = `
 <http://kboOrgUri> a <http://mu.semte.ch/vocabularies/ext/KboOrganisatie> ; 
     <http://mu.semte.ch/vocabularies/core/uuid> """kboOrgUuid""" ;

--- a/test/lib/queries.test.js
+++ b/test/lib/queries.test.js
@@ -6,6 +6,7 @@ import {
   buildKboAddressQueryDefault,
   buildContactPointQueryFull,
   buildContactPointQueryDefault,
+  buildKboIdentifierQueryFull,
   buildKboOrgQueryFull,
   buildKboOrgQueryDefault,
   buildUpdateQueryFull,
@@ -25,6 +26,7 @@ const updateSudoStub = sinon.stub();
 const {
   buildKboAddressQuery,
   buildContactPointQuery,
+  buildKboIdentifierQuery,
   buildKboOrgQuery,
   buildUpdateQuery,
   updateKboOrg,
@@ -115,6 +117,21 @@ describe("Queries", () => {
     });
   });
 
+  describe("buildKboIdentifierQuery", () => {
+    it("should return the correct query", () => {
+      const result = buildKboIdentifierQuery(
+        "http://kboIdentifierUri",
+        "kboIdentifierUuid",
+        "http://abbOrgKboIdentifierUri",
+        "0207437468"
+      );
+      assert.strictEqual(
+        normalize(result),
+        normalize(buildKboIdentifierQueryFull)
+      );
+    });
+  });
+
   describe("buildKboOrgQuery", () => {
     it("should return the correct query", () => {
       const result = buildKboOrgQuery(
@@ -132,10 +149,7 @@ describe("Queries", () => {
           activeState: "activeState",
         }
       );
-      assert.strictEqual(
-        normalize(result),
-        normalize(buildKboOrgQueryFull)
-      );
+      assert.strictEqual(normalize(result), normalize(buildKboOrgQueryFull));
     });
 
     it("should return the correct query with empty kboFields", () => {
@@ -147,10 +161,7 @@ describe("Queries", () => {
         "http://abbOrgUri",
         {}
       );
-      assert.strictEqual(
-        normalize(result),
-        normalize(buildKboOrgQueryDefault)
-      );
+      assert.strictEqual(normalize(result), normalize(buildKboOrgQueryDefault));
     });
   });
 
@@ -164,10 +175,7 @@ describe("Queries", () => {
         "<http://mu.semte.ch/graphs/administrative-unit>"
       );
 
-      assert.strictEqual(
-        normalize(result),
-        normalize(buildUpdateQueryFull)
-      );
+      assert.strictEqual(normalize(result), normalize(buildUpdateQueryFull));
     });
     it("should return the correct query when object is undefined", () => {
       const result = buildUpdateQuery(
@@ -178,10 +186,7 @@ describe("Queries", () => {
         "<http://mu.semte.ch/graphs/administrative-unit>"
       );
 
-      assert.strictEqual(
-        normalize(result),
-        normalize(buildUpdateQueryDefault)
-      );
+      assert.strictEqual(normalize(result), normalize(buildUpdateQueryDefault));
     });
   });
 
@@ -226,9 +231,7 @@ describe("Queries", () => {
 
     it("should return the correct query with empty kboFields", async () => {
       await updateKboOrg(
-        {
-
-        },
+        {},
         {
           addressUri: "http://addressUri",
           contactPointUri: "http://contactPointUri",

--- a/typedefs.js
+++ b/typedefs.js
@@ -4,7 +4,7 @@
  * @property {string} [changeTime] The change time of the data.
  * @property {string} [shortName] The short name of the organization.
  * @property {string} [ovoNumber] The OVO number of the organization.
- * @property {string} [kboNumber] The KBO number of the organization.
+ * @property {string} kboNumber The KBO number of the organization.
  * @property {string} [formalName] The formal name of the organization.
  * @property {string} [startDate] The start date of the organization.
  * @property {string} [activeState] The active state of the organization.


### PR DESCRIPTION
This pull request fixes the issue where the <http://www.w3.org/2002/07/owl#sameAs> value on `kboOrganisaties` was being overridden when the OVO number was updated. 

Originally, the creation and updating of the OVO number did not involve handling kboOrganisaties.

Consequently:
- When the OVO number was initially added to the ABB organization, it was also added to kboOrganisaties because they share the same KBO Identifier.
- Subsequent updates would then replace the value of sameAs on kboOrganisaties with the OVO URI.

Modifications: 
- Only append OVO number to ABB organisation
- Exclude KBO organizations when seeking ABB organizations
- Introduce a distinct 'KboIdentifier' for KBO organizations to prevent erroneous matches while filtering on 'KboIdentifier'.

Related to OP-3174