### PR TITLE
Values can have different data types

### DIFF
--- a/.woodpecker/.latest.yml
+++ b/.woodpecker/.latest.yml
@@ -1,10 +1,13 @@
-pipeline:
-  build:
-    image: plugins/docker
+steps:
+  build-and-push:
+    image: woodpeckerci/plugin-docker-buildx
     settings:
       repo: ${CI_REPO}
       tags: latest
-    secrets: [ docker_username, docker_password ]
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
 when:
-  branch: master
-  event: push
+  - event: push
+    branch: [master, main]

--- a/.woodpecker/.release.yml
+++ b/.woodpecker/.release.yml
@@ -1,10 +1,13 @@
-pipeline:
-  build:
-    image: plugins/docker
+steps:
+  release:
+    image: woodpeckerci/plugin-docker-buildx
     settings:
       repo: ${CI_REPO}
       tags: "${CI_COMMIT_TAG##v}"
-    secrets: [ docker_username, docker_password ]
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
 when:
-  event: tag
-  tag: v*
+  - event: tag
+    ref: refs/tags/v*

--- a/.woodpecker/.test-build.yml
+++ b/.woodpecker/.test-build.yml
@@ -1,9 +1,8 @@
-pipeline:
-  build:
-    image: plugins/docker
+steps:
+  testbuild:
+    image: woodpeckerci/plugin-docker-buildx
     settings:
       repo: ${CI_REPO}
       dry_run: true
 when:
-  event:
-    - pull_request
+  - event: pull_request

--- a/.woodpecker/.test-pr.yml
+++ b/.woodpecker/.test-pr.yml
@@ -1,4 +1,4 @@
-pipeline:
+steps:
   install:
     image: node:20
     commands:
@@ -12,5 +12,4 @@ pipeline:
     commands:
       - npm test
 when:
-  event:
-    - pull_request
+  - event: pull_request

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,2 @@
 FROM semtech/mu-javascript-template:1.8.0
 LABEL maintainer="redpencil.io <info@repdencil.io>"
-

--- a/lib/queries.js
+++ b/lib/queries.js
@@ -1,4 +1,4 @@
-import { uuid, sparqlEscapeUri, sparqlEscapeString } from "mu";
+import { uuid, sparqlEscapeUri, sparqlEscapeString, sparqlEscapeDate } from "mu";
 import { querySudo as query, updateSudo as update } from "@lblod/mu-auth-sudo";
 
 const graphs = [
@@ -475,7 +475,7 @@ export const buildKboOrgQuery = (
     )} `;
   }
   if (kboFields.startDate) {
-    kboOrgStr += `; <http://mu.semte.ch/vocabularies/ext/startDate> ${sparqlEscapeString(
+    kboOrgStr += `; <http://mu.semte.ch/vocabularies/ext/startDate> ${sparqlEscapeDate(
       kboFields.startDate
     )} `;
   }
@@ -490,7 +490,7 @@ export const buildKboOrgQuery = (
     )} `;
   }
   if (kboFields.changeTime) {
-    kboOrgStr += `; <http://purl.org/dc/terms/modified> ${sparqlEscapeString(
+    kboOrgStr += `; <http://purl.org/dc/terms/modified> ${sparqlEscapeDate(
       kboFields.changeTime
     )} `;
   }
@@ -586,6 +586,7 @@ export const createKboOrg = async (
  * @param {string} type The type of the subject.
  * @param {string} predicate The predicate of the triple.
  * @param {string} value The new object of the triple.
+ * @param {string} valueDataType The data type of the object of the triple.
  * @param {string} graphValues The values of the graph.
  * @returns {string} The query to update the predicate.
  */
@@ -594,10 +595,26 @@ export const buildUpdateQuery = (
   type,
   predicate,
   value,
+  valueDataType,
   graphValues
 ) => {
   const escapedSubject = sparqlEscapeUri(subject);
   const escapedPredicate = sparqlEscapeUri(predicate);
+
+  let escapedValue;
+  switch (valueDataType) {
+    case "string":
+      escapedValue = sparqlEscapeString(value);
+      break;
+    case "date":
+      escapedValue = sparqlEscapeDate(value);
+      break;
+    case "uri":
+      escapedValue = sparqlEscapeUri(value);
+      break;
+    default:
+      escapedValue = sparqlEscapeString(value);
+  }
 
   const deleteQuery = `
     DELETE {
@@ -618,7 +635,7 @@ export const buildUpdateQuery = (
     ? `;
     INSERT {
       GRAPH ?g { 
-        ?s ${escapedPredicate} ${sparqlEscapeString(value)} .
+        ?s ${escapedPredicate} ${escapedValue} .
       }
     }
     WHERE {
@@ -645,6 +662,7 @@ const updateKboAddress = async (addressUri, formattedAddress) => {
     "http://www.w3.org/ns/locn#Address",
     "http://www.w3.org/ns/locn#fullAddress",
     formattedAddress,
+    'string',
     graphValues
   );
 
@@ -663,6 +681,7 @@ const updateKboContactPoint = async (contactPointUri, kboFields) => {
     "http://schema.org/ContactPoint",
     "http://schema.org/email",
     kboFields.email,
+    'string',
     graphValues
   );
 
@@ -671,6 +690,7 @@ const updateKboContactPoint = async (contactPointUri, kboFields) => {
     "http://schema.org/ContactPoint",
     "http://schema.org/telephone",
     kboFields.phone,
+    'string',
     graphValues
   );
 
@@ -679,6 +699,7 @@ const updateKboContactPoint = async (contactPointUri, kboFields) => {
     "http://schema.org/ContactPoint",
     "http://xmlns.com/foaf/0.1/page",
     kboFields.website,
+    'string',
     graphValues
   );
 
@@ -704,6 +725,7 @@ const updateKboOrganization = async (kboOrgUri, kboFields) => {
     "http://mu.semte.ch/vocabularies/ext/KboOrganisatie",
     "http://mu.semte.ch/vocabularies/ext/rechtsvorm",
     kboFields.rechtsvorm,
+    'string',
     graphValues
   );
 
@@ -712,6 +734,7 @@ const updateKboOrganization = async (kboOrgUri, kboFields) => {
     "http://mu.semte.ch/vocabularies/ext/KboOrganisatie",
     "http://www.w3.org/2004/02/skos/core#altLabel",
     kboFields.shortName,
+    'string',
     graphValues
   );
 
@@ -720,6 +743,7 @@ const updateKboOrganization = async (kboOrgUri, kboFields) => {
     "http://mu.semte.ch/vocabularies/ext/KboOrganisatie",
     "http://mu.semte.ch/vocabularies/ext/startDate",
     kboFields.startDate,
+    'date',
     graphValues
   );
 
@@ -728,6 +752,7 @@ const updateKboOrganization = async (kboOrgUri, kboFields) => {
     "http://mu.semte.ch/vocabularies/ext/KboOrganisatie",
     "http://www.w3.org/ns/regorg#legalName",
     kboFields.formalName,
+    'string',
     graphValues
   );
 
@@ -736,6 +761,7 @@ const updateKboOrganization = async (kboOrgUri, kboFields) => {
     "http://mu.semte.ch/vocabularies/ext/KboOrganisatie",
     "http://purl.org/dc/terms/modified",
     kboFields.changeTime,
+    'date',
     graphValues
   );
 
@@ -744,6 +770,7 @@ const updateKboOrganization = async (kboOrgUri, kboFields) => {
     "http://mu.semte.ch/vocabularies/ext/KboOrganisatie",
     "http://www.w3.org/ns/regorg#orgStatus",
     kboFields.activeState,
+    'uri',
     graphValues
   );
 

--- a/lib/queries.js
+++ b/lib/queries.js
@@ -54,7 +54,7 @@ export async function getAbbOrganizationInfo(kboStructuredIdUuid) {
             <http://www.w3.org/2004/02/skos/core#notation> ?ovoNotation .
 
           OPTIONAL { ?ovoStructuredId <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> ?ovo . }
-          
+
           FILTER (?ovoNotation IN ("OVO-nummer"@nl, "OVO-nummer"))
         }
       }
@@ -273,15 +273,15 @@ export async function getAllAbbKboOrganizations() {
        GRAPH ?g {
          ?kboId <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator> ?kboStructuredId ;
                <http://www.w3.org/2004/02/skos/core#notation> ?kboNotation .
-     
+
          ?kboStructuredId a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
                <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> ?kbo .
-     
+
          ?abbOrg <http://www.w3.org/ns/adms#identifier> ?kboId .
-     
+
          FILTER (?kboNotation IN ("KBO nummer"@nl, "KBO nummer"))
          FILTER (!regex(?abbOrg, "kboOrganisaties","i"))
-     
+
          OPTIONAL{
           ?kboOrg a <http://mu.semte.ch/vocabularies/ext/KboOrganisatie> ;
               <http://www.w3.org/2002/07/owl#sameAs> ?abbOrg ;
@@ -289,7 +289,7 @@ export async function getAllAbbKboOrganizations() {
          }
          OPTIONAL{
           ?abbOrg <http://www.w3.org/ns/adms#identifier> ?ovoId .
- 
+
           ?ovoId <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator> ?ovoStructuredId ;
             <http://www.w3.org/2004/02/skos/core#notation> ?ovoNotation .
 
@@ -419,8 +419,8 @@ export const buildKboIdentifierQuery = (
       <http://purl.org/dc/terms/source> <https://economie.fgov.be/> ;
       <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> ${sparqlEscapeString(
         kboNumber
-      )} . 
-  
+      )} .
+
     ${sparqlEscapeUri(
       kboIdentifierUri
     )} a <http://www.w3.org/ns/adms#Identifier> ;
@@ -579,7 +579,7 @@ export const createKboOrg = async (
 
       FILTER(?abbOrg = ${sparqlEscapeUri(abbOrgUri)})
     }
-  } 
+  }
   `;
 
   await update(updateStr);
@@ -628,7 +628,7 @@ export const buildUpdateQuery = (
   const insertQuery = escapedValue
     ? `;
     INSERT {
-      GRAPH ?g { 
+      GRAPH ?g {
         ?s ${escapedPredicate} ${escapedValue} .
       }
     }

--- a/lib/queries.js
+++ b/lib/queries.js
@@ -369,17 +369,17 @@ export const buildContactPointQuery = (
     <http://www.w3.org/ns/locn#address> ${sparqlEscapeUri(addressUri)} `;
 
   if (kboFields.email) {
-    contactPointStr += `; 
+    contactPointStr += `;
     <http://schema.org/email> ${sparqlEscapeString(kboFields.email)} `;
   }
 
   if (kboFields.phone) {
-    contactPointStr += `; 
+    contactPointStr += `;
     <http://schema.org/telephone> ${sparqlEscapeString(kboFields.phone)} `;
   }
 
   if (kboFields.website) {
-    contactPointStr += `; 
+    contactPointStr += `;
     <http://xmlns.com/foaf/0.1/page> ${sparqlEscapeString(kboFields.website)} `;
   }
 

--- a/lib/queries.js
+++ b/lib/queries.js
@@ -602,18 +602,20 @@ export const buildUpdateQuery = (
   const escapedPredicate = sparqlEscapeUri(predicate);
 
   let escapedValue;
-  switch (valueDataType) {
-    case "string":
-      escapedValue = sparqlEscapeString(value);
-      break;
-    case "date":
-      escapedValue = sparqlEscapeDate(value);
-      break;
-    case "uri":
-      escapedValue = sparqlEscapeUri(value);
-      break;
-    default:
-      escapedValue = sparqlEscapeString(value);
+  if (value) {
+    switch (valueDataType) {
+      case "string":
+        escapedValue = sparqlEscapeString(value);
+        break;
+      case "date":
+        escapedValue = sparqlEscapeDate(value);
+        break;
+      case "uri":
+        escapedValue = sparqlEscapeUri(value);
+        break;
+      default:
+        escapedValue = sparqlEscapeString(value);
+    }
   }
 
   const deleteQuery = `

--- a/lib/queries.js
+++ b/lib/queries.js
@@ -5,7 +5,14 @@ const graphs = [
   "http://mu.semte.ch/graphs/administrative-unit",
   "http://mu.semte.ch/graphs/worship-service",
 ];
+
 const graphValues = graphs.map((graph) => sparqlEscapeUri(graph)).join(" ");
+
+export const dataValueType = {
+  STRING: sparqlEscapeString,
+  DATE: sparqlEscapeDate,
+  URI: sparqlEscapeUri,
+}
 
 /**
  * Represents the information of the ABB organization.
@@ -582,41 +589,26 @@ export const createKboOrg = async (
 
 /**
  * Build the query to update a predicate, deleting the old value and inserting the new one if exist.
+ * @param {string} graphValues The values of the graph.
  * @param {string} subject The subject of the triple.
  * @param {string} type The type of the subject.
  * @param {string} predicate The predicate of the triple.
  * @param {string} value The new object of the triple.
- * @param {string} valueDataType The data type of the object of the triple.
- * @param {string} graphValues The values of the graph.
+ * @param {string} valueEscapeFunction The escape function to apply when saving the value
  * @returns {string} The query to update the predicate.
  */
 export const buildUpdateQuery = (
+  graphValues,
   subject,
   type,
   predicate,
   value,
-  valueDataType,
-  graphValues
+  valueEscapeFunction = sparqlEscapeString,
 ) => {
   const escapedSubject = sparqlEscapeUri(subject);
   const escapedPredicate = sparqlEscapeUri(predicate);
 
-  let escapedValue;
-  if (value) {
-    switch (valueDataType) {
-      case "string":
-        escapedValue = sparqlEscapeString(value);
-        break;
-      case "date":
-        escapedValue = sparqlEscapeDate(value);
-        break;
-      case "uri":
-        escapedValue = sparqlEscapeUri(value);
-        break;
-      default:
-        escapedValue = sparqlEscapeString(value);
-    }
-  }
+  let escapedValue = value ? valueEscapeFunction.apply(null, [value]) : value;
 
   const deleteQuery = `
     DELETE {
@@ -633,7 +625,7 @@ export const buildUpdateQuery = (
       }
     }`;
 
-  const insertQuery = value
+  const insertQuery = escapedValue
     ? `;
     INSERT {
       GRAPH ?g { 
@@ -660,12 +652,11 @@ export const buildUpdateQuery = (
  */
 const updateKboAddress = async (addressUri, formattedAddress) => {
   const query = buildUpdateQuery(
+    graphValues,
     addressUri,
     "http://www.w3.org/ns/locn#Address",
     "http://www.w3.org/ns/locn#fullAddress",
-    formattedAddress,
-    'string',
-    graphValues
+    formattedAddress
   );
 
   await update(query);
@@ -679,30 +670,27 @@ const updateKboAddress = async (addressUri, formattedAddress) => {
  */
 const updateKboContactPoint = async (contactPointUri, kboFields) => {
   const updateEmailQuery = buildUpdateQuery(
+    graphValues,
     contactPointUri,
     "http://schema.org/ContactPoint",
     "http://schema.org/email",
-    kboFields.email,
-    'string',
-    graphValues
+    kboFields.email
   );
 
   const updatePhoneQuery = buildUpdateQuery(
+    graphValues,
     contactPointUri,
     "http://schema.org/ContactPoint",
     "http://schema.org/telephone",
-    kboFields.phone,
-    'string',
-    graphValues
+    kboFields.phone
   );
 
   const updateWebsiteQuery = buildUpdateQuery(
+    graphValues,
     contactPointUri,
     "http://schema.org/ContactPoint",
     "http://xmlns.com/foaf/0.1/page",
-    kboFields.website,
-    'string',
-    graphValues
+    kboFields.website
   );
 
   const query = `
@@ -723,57 +711,54 @@ const updateKboContactPoint = async (contactPointUri, kboFields) => {
  */
 const updateKboOrganization = async (kboOrgUri, kboFields) => {
   const updateRechtsvormQuery = buildUpdateQuery(
+    graphValues,
     kboOrgUri,
     "http://mu.semte.ch/vocabularies/ext/KboOrganisatie",
     "http://mu.semte.ch/vocabularies/ext/rechtsvorm",
-    kboFields.rechtsvorm,
-    'string',
-    graphValues
+    kboFields.rechtsvorm
   );
 
   const updateShortNameQuery = buildUpdateQuery(
+    graphValues,
     kboOrgUri,
     "http://mu.semte.ch/vocabularies/ext/KboOrganisatie",
     "http://www.w3.org/2004/02/skos/core#altLabel",
-    kboFields.shortName,
-    'string',
-    graphValues
+    kboFields.shortName
   );
 
   const updateStartDateQuery = buildUpdateQuery(
+    graphValues,
     kboOrgUri,
     "http://mu.semte.ch/vocabularies/ext/KboOrganisatie",
     "http://mu.semte.ch/vocabularies/ext/startDate",
     kboFields.startDate,
-    'date',
-    graphValues
+    dataValueType.DATE
   );
 
   const updateFormalNameQuery = buildUpdateQuery(
+    graphValues,
     kboOrgUri,
     "http://mu.semte.ch/vocabularies/ext/KboOrganisatie",
     "http://www.w3.org/ns/regorg#legalName",
-    kboFields.formalName,
-    'string',
-    graphValues
+    kboFields.formalName
   );
 
   const updateModifiedQuery = buildUpdateQuery(
+    graphValues,
     kboOrgUri,
     "http://mu.semte.ch/vocabularies/ext/KboOrganisatie",
     "http://purl.org/dc/terms/modified",
     kboFields.changeTime,
-    'date',
-    graphValues
+    dataValueType.DATE
   );
 
   const updateActiveStateQuery = buildUpdateQuery(
+    graphValues,
     kboOrgUri,
     "http://mu.semte.ch/vocabularies/ext/KboOrganisatie",
     "http://www.w3.org/ns/regorg#orgStatus",
     kboFields.activeState,
-    'uri',
-    graphValues
+    dataValueType.URI,
   );
 
   const query = `

--- a/package.json
+++ b/package.json
@@ -15,13 +15,13 @@
     "node-fetch": "^2.6.1"
   },
   "devDependencies": {
-    "@babel/register": "^7.23.7",
-    "@eslint/js": "^9.0.0",
-    "eslint": "^9.0.0",
-    "eslint-plugin-jsdoc": "^48.2.3",
-    "esmock": "^2.6.4",
-    "mocha": "^10.4.0",
-    "sinon": "^17.0.1"
+    "@babel/register": "^7.25.9",
+    "@eslint/js": "^9.24.0",
+    "eslint": "^9.24.0",
+    "eslint-plugin-jsdoc": "^50.6.9",
+    "esmock": "^2.7.0",
+    "mocha": "^11.1.0",
+    "sinon": "^20.0.0"
   },
   "pre-commit": [
     "lint"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "@lblod/mu-auth-sudo": "^0.6.1",
+    "@lblod/mu-auth-sudo": "^0.6.2",
     "cron": "^3.0.0",
     "node-fetch": "^2.6.1"
   },

--- a/test/lib/queries.data.js
+++ b/test/lib/queries.data.js
@@ -47,16 +47,16 @@ export const buildKboIdentifierQueryFull = `
 export const buildKboOrgQueryFull = `
 <http://kboOrgUri> a <http://mu.semte.ch/vocabularies/ext/KboOrganisatie> ; 
     <http://mu.semte.ch/vocabularies/core/uuid> """kboOrgUuid""" ;
-    <http://purl.org/dc/terms/source> <https://economie.fgov.be/> ; 
-    <http://www.w3.org/2002/07/owl#sameAs> <http://abbOrgUri> ; 
-    <http://schema.org/contactPoint> <http://contactPointUri> ; 
-    <http://www.w3.org/ns/adms#identifier> <http://kboIdentifierUri> ; 
-    <http://mu.semte.ch/vocabularies/ext/rechtsvorm> """Stad / gemeente""" ; 
-    <http://mu.semte.ch/vocabularies/ext/startDate> """1968-01-01""" ; 
-    <http://www.w3.org/ns/regorg#legalName> """formalName""" ; 
-    <http://www.w3.org/2004/02/skos/core#altLabel> """shortName""" ; 
-    <http://purl.org/dc/terms/modified> """2024-01-01""" ; 
-    <http://www.w3.org/ns/regorg#orgStatus> <activeState> .
+    <http://purl.org/dc/terms/source> <https://economie.fgov.be/> ;
+    <http://www.w3.org/2002/07/owl#sameAs> <http://abbOrgUri> ;
+    <http://schema.org/contactPoint> <http://contactPointUri> ;
+    <http://www.w3.org/ns/adms#identifier> <http://kboIdentifierUri> ;
+    <http://mu.semte.ch/vocabularies/ext/rechtsvorm> """Stad / gemeente""" ;
+    <http://mu.semte.ch/vocabularies/ext/startDate> "1968-01-01"^^xsd:date ;
+    <http://www.w3.org/ns/regorg#legalName> """formalName""" ;
+    <http://www.w3.org/2004/02/skos/core#altLabel> """shortName""" ;
+    <http://purl.org/dc/terms/modified> "2024-01-01"^^xsd:date ;
+    <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
 `;
 
 export const buildKboOrgQueryDefault = `
@@ -85,7 +85,7 @@ WHERE {
 ;
 INSERT { 
   GRAPH ?g { 
-    ?s <http://purl.org/dc/terms/modified> """2024-01-01""" . 
+    ?s <http://purl.org/dc/terms/modified> "2024-01-01"^^xsd:date . 
   } 
 } 
 WHERE { 
@@ -267,7 +267,7 @@ WHERE {
 } 
 ; 
 INSERT { 
-    GRAPH ?g { ?s <http://mu.semte.ch/vocabularies/ext/startDate> """1968-01-01""" . } 
+    GRAPH ?g { ?s <http://mu.semte.ch/vocabularies/ext/startDate> "1968-01-01"^^xsd:date . } 
 } 
 WHERE { 
     VALUES ?g { <http://mu.semte.ch/graphs/administrative-unit> <http://mu.semte.ch/graphs/worship-service> } 
@@ -313,7 +313,7 @@ WHERE {
 } 
 ; 
 INSERT { 
-    GRAPH ?g { ?s <http://purl.org/dc/terms/modified> """2023-11-15""" . } 
+    GRAPH ?g { ?s <http://purl.org/dc/terms/modified> "2023-11-15"^^xsd:date . } 
 } 
 WHERE { 
     VALUES ?g { <http://mu.semte.ch/graphs/administrative-unit> <http://mu.semte.ch/graphs/worship-service> } 
@@ -336,7 +336,7 @@ WHERE {
 } 
 ; 
 INSERT { 
-    GRAPH ?g { ?s <http://www.w3.org/ns/regorg#orgStatus> """active""" . } 
+    GRAPH ?g { ?s <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> . } 
 } 
 WHERE { 
     VALUES ?g { <http://mu.semte.ch/graphs/administrative-unit> <http://mu.semte.ch/graphs/worship-service> } 

--- a/test/lib/queries.data.js
+++ b/test/lib/queries.data.js
@@ -40,12 +40,12 @@ export const buildKboIdentifierQueryFull = `
   <http://mu.semte.ch/vocabularies/core/uuid> """kboIdentifierUuid""" ;
   <http://purl.org/dc/terms/source> <https://economie.fgov.be/> ;
   <http://www.w3.org/2004/02/skos/core#notation> """KBO nummer""" ;
-  <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator> <http://data.lblod.info/id/gestructureerdeIdentificator/1234567890> ; 
+  <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator> <http://data.lblod.info/id/gestructureerdeIdentificator/1234567890> ;
   <http://www.w3.org/2002/07/owl#sameAs> <http://abbOrgKboIdentifierUri> .
 `;
 
 export const buildKboOrgQueryFull = `
-<http://kboOrgUri> a <http://mu.semte.ch/vocabularies/ext/KboOrganisatie> ; 
+<http://kboOrgUri> a <http://mu.semte.ch/vocabularies/ext/KboOrganisatie> ;
     <http://mu.semte.ch/vocabularies/core/uuid> """kboOrgUuid""" ;
     <http://purl.org/dc/terms/source> <https://economie.fgov.be/> ;
     <http://www.w3.org/2002/07/owl#sameAs> <http://abbOrgUri> ;
@@ -60,11 +60,11 @@ export const buildKboOrgQueryFull = `
 `;
 
 export const buildKboOrgQueryDefault = `
-<http://kboOrgUri> a <http://mu.semte.ch/vocabularies/ext/KboOrganisatie> ; 
+<http://kboOrgUri> a <http://mu.semte.ch/vocabularies/ext/KboOrganisatie> ;
     <http://mu.semte.ch/vocabularies/core/uuid> """kboOrgUuid""" ;
-    <http://purl.org/dc/terms/source> <https://economie.fgov.be/> ; 
-    <http://www.w3.org/2002/07/owl#sameAs> <http://abbOrgUri> ; 
-    <http://schema.org/contactPoint> <http://contactPointUri> ; 
+    <http://purl.org/dc/terms/source> <https://economie.fgov.be/> ;
+    <http://www.w3.org/2002/07/owl#sameAs> <http://abbOrgUri> ;
+    <http://schema.org/contactPoint> <http://contactPointUri> ;
     <http://www.w3.org/ns/adms#identifier> <http://kboIdentifierUri> .
 `;
 
@@ -121,9 +121,9 @@ WHERE {
   VALUES ?g { <http://mu.semte.ch/graphs/administrative-unit> <http://mu.semte.ch/graphs/worship-service> } 
   GRAPH ?g {
     BIND (<http://addressUri> AS ?s) 
-    ?s a <http://www.w3.org/ns/locn#Address> ; 
+    ?s a <http://www.w3.org/ns/locn#Address> ;
       <http://www.w3.org/ns/locn#fullAddress> ?o . } } 
-; 
+;
 INSERT { 
   GRAPH ?g { 
     ?s <http://www.w3.org/ns/locn#fullAddress> """Werf 9, 9300 Aalst, België""" . 
@@ -146,11 +146,11 @@ WHERE {
   VALUES ?g { <http://mu.semte.ch/graphs/administrative-unit> <http://mu.semte.ch/graphs/worship-service> } 
   GRAPH ?g {
     BIND (<http://contactPointUri> AS ?s) 
-    ?s a <http://schema.org/ContactPoint> ; 
+    ?s a <http://schema.org/ContactPoint> ;
       <http://schema.org/email> ?o . 
   } 
 } 
-; 
+;
 INSERT { 
   GRAPH ?g { ?s <http://schema.org/email> """info@aalst.be""" . } 
 } 
@@ -161,7 +161,7 @@ WHERE {
     ?s a <http://schema.org/ContactPoint> . 
   } 
 } 
-; 
+;
 DELETE { 
   GRAPH ?g { ?s <http://schema.org/telephone> ?o . } 
 } 
@@ -169,11 +169,11 @@ WHERE {
   VALUES ?g { <http://mu.semte.ch/graphs/administrative-unit> <http://mu.semte.ch/graphs/worship-service> } 
   GRAPH ?g {
     BIND (<http://contactPointUri> AS ?s) 
-    ?s a <http://schema.org/ContactPoint> ; 
+    ?s a <http://schema.org/ContactPoint> ;
       <http://schema.org/telephone> ?o . 
   } 
 } 
-; 
+;
 INSERT { 
   GRAPH ?g { ?s <http://schema.org/telephone> """053 77 93 00""" . } 
 } WHERE { 
@@ -183,7 +183,7 @@ INSERT {
     ?s a <http://schema.org/ContactPoint> .
   } 
 } 
-; 
+;
 DELETE { 
   GRAPH ?g { ?s <http://xmlns.com/foaf/0.1/page> ?o . } 
 } 
@@ -191,11 +191,11 @@ WHERE {
   VALUES ?g { <http://mu.semte.ch/graphs/administrative-unit> <http://mu.semte.ch/graphs/worship-service> } 
   GRAPH ?g {
     BIND (<http://contactPointUri> AS ?s) 
-    ?s a <http://schema.org/ContactPoint> ; 
+    ?s a <http://schema.org/ContactPoint> ;
       <http://xmlns.com/foaf/0.1/page> ?o . 
   } 
 } 
-; 
+;
 INSERT { 
   GRAPH ?g { ?s <http://xmlns.com/foaf/0.1/page> """https://www.aalst.be""" . } 
 } WHERE { 
@@ -215,11 +215,11 @@ WHERE {
     VALUES ?g { <http://mu.semte.ch/graphs/administrative-unit> <http://mu.semte.ch/graphs/worship-service> } 
     GRAPH ?g {
         BIND (<http://kboOrgUri> AS ?s) 
-        ?s a <http://mu.semte.ch/vocabularies/ext/KboOrganisatie> ; 
+        ?s a <http://mu.semte.ch/vocabularies/ext/KboOrganisatie> ;
             <http://mu.semte.ch/vocabularies/ext/rechtsvorm> ?o . 
     } 
 } 
-; 
+;
 INSERT { 
     GRAPH ?g { ?s <http://mu.semte.ch/vocabularies/ext/rechtsvorm> """Stad/Gemeente""" . } 
 } 
@@ -230,7 +230,7 @@ WHERE {
         ?s a <http://mu.semte.ch/vocabularies/ext/KboOrganisatie> . 
     } 
 } 
-; 
+;
 DELETE { 
     GRAPH ?g { ?s <http://www.w3.org/2004/02/skos/core#altLabel> ?o . } 
 } 
@@ -238,11 +238,11 @@ WHERE {
     VALUES ?g { <http://mu.semte.ch/graphs/administrative-unit> <http://mu.semte.ch/graphs/worship-service> } 
     GRAPH ?g {
         BIND (<http://kboOrgUri> AS ?s) 
-        ?s a <http://mu.semte.ch/vocabularies/ext/KboOrganisatie> ; 
+        ?s a <http://mu.semte.ch/vocabularies/ext/KboOrganisatie> ;
             <http://www.w3.org/2004/02/skos/core#altLabel> ?o . 
     } 
 } 
-; 
+;
 INSERT { 
     GRAPH ?g { ?s <http://www.w3.org/2004/02/skos/core#altLabel> """Aalst""" . } 
 } 
@@ -253,7 +253,7 @@ WHERE {
         ?s a <http://mu.semte.ch/vocabularies/ext/KboOrganisatie> . 
     } 
 } 
-; 
+;
 DELETE { 
     GRAPH ?g { ?s <http://mu.semte.ch/vocabularies/ext/startDate> ?o . } 
 } 
@@ -261,11 +261,11 @@ WHERE {
     VALUES ?g { <http://mu.semte.ch/graphs/administrative-unit> <http://mu.semte.ch/graphs/worship-service> } 
     GRAPH ?g {
         BIND (<http://kboOrgUri> AS ?s) 
-        ?s a <http://mu.semte.ch/vocabularies/ext/KboOrganisatie> ; 
+        ?s a <http://mu.semte.ch/vocabularies/ext/KboOrganisatie> ;
             <http://mu.semte.ch/vocabularies/ext/startDate> ?o . 
     } 
 } 
-; 
+;
 INSERT { 
     GRAPH ?g { ?s <http://mu.semte.ch/vocabularies/ext/startDate> "1968-01-01"^^xsd:date . } 
 } 
@@ -276,7 +276,7 @@ WHERE {
         ?s a <http://mu.semte.ch/vocabularies/ext/KboOrganisatie> . 
     } 
 } 
-; 
+;
 DELETE { 
     GRAPH ?g { ?s <http://www.w3.org/ns/regorg#legalName> ?o . } 
 } 
@@ -284,11 +284,11 @@ WHERE {
     VALUES ?g { <http://mu.semte.ch/graphs/administrative-unit> <http://mu.semte.ch/graphs/worship-service> } 
     GRAPH ?g {
         BIND (<http://kboOrgUri> AS ?s) 
-        ?s a <http://mu.semte.ch/vocabularies/ext/KboOrganisatie> ; 
+        ?s a <http://mu.semte.ch/vocabularies/ext/KboOrganisatie> ;
             <http://www.w3.org/ns/regorg#legalName> ?o . 
     } 
 } 
-; 
+;
 INSERT { 
     GRAPH ?g { ?s <http://www.w3.org/ns/regorg#legalName> """Stad Aalst""" . } 
 } 
@@ -299,7 +299,7 @@ WHERE {
         ?s a <http://mu.semte.ch/vocabularies/ext/KboOrganisatie> . 
     } 
 } 
-; 
+;
 DELETE { 
     GRAPH ?g { ?s <http://purl.org/dc/terms/modified> ?o . } 
 } 
@@ -307,11 +307,11 @@ WHERE {
     VALUES ?g { <http://mu.semte.ch/graphs/administrative-unit> <http://mu.semte.ch/graphs/worship-service> } 
     GRAPH ?g {
         BIND (<http://kboOrgUri> AS ?s) 
-        ?s a <http://mu.semte.ch/vocabularies/ext/KboOrganisatie> ; 
+        ?s a <http://mu.semte.ch/vocabularies/ext/KboOrganisatie> ;
             <http://purl.org/dc/terms/modified> ?o . 
     } 
 } 
-; 
+;
 INSERT { 
     GRAPH ?g { ?s <http://purl.org/dc/terms/modified> "2023-11-15"^^xsd:date . } 
 } 
@@ -322,7 +322,7 @@ WHERE {
         ?s a <http://mu.semte.ch/vocabularies/ext/KboOrganisatie> . 
     } 
 } 
-; 
+;
 DELETE { 
     GRAPH ?g { ?s <http://www.w3.org/ns/regorg#orgStatus> ?o . } 
 } 
@@ -330,11 +330,11 @@ WHERE {
     VALUES ?g { <http://mu.semte.ch/graphs/administrative-unit> <http://mu.semte.ch/graphs/worship-service> } 
     GRAPH ?g {
         BIND (<http://kboOrgUri> AS ?s) 
-        ?s a <http://mu.semte.ch/vocabularies/ext/KboOrganisatie> ; 
+        ?s a <http://mu.semte.ch/vocabularies/ext/KboOrganisatie> ;
             <http://www.w3.org/ns/regorg#orgStatus> ?o . 
     } 
 } 
-; 
+;
 INSERT { 
     GRAPH ?g { ?s <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> . } 
 } 
@@ -355,7 +355,7 @@ WHERE {
   VALUES ?g { <http://mu.semte.ch/graphs/administrative-unit> <http://mu.semte.ch/graphs/worship-service> } 
   GRAPH ?g {
     BIND (<http://addressUri> AS ?s) 
-    ?s a <http://www.w3.org/ns/locn#Address> ; 
+    ?s a <http://www.w3.org/ns/locn#Address> ;
       <http://www.w3.org/ns/locn#fullAddress> ?o . } } 
 `;
 
@@ -367,11 +367,11 @@ WHERE {
   VALUES ?g { <http://mu.semte.ch/graphs/administrative-unit> <http://mu.semte.ch/graphs/worship-service> } 
   GRAPH ?g {
     BIND (<http://contactPointUri> AS ?s) 
-    ?s a <http://schema.org/ContactPoint> ; 
+    ?s a <http://schema.org/ContactPoint> ;
       <http://schema.org/email> ?o . 
   } 
 } 
-; 
+;
 DELETE { 
   GRAPH ?g { ?s <http://schema.org/telephone> ?o . } 
 } 
@@ -379,11 +379,11 @@ WHERE {
   VALUES ?g { <http://mu.semte.ch/graphs/administrative-unit> <http://mu.semte.ch/graphs/worship-service> } 
   GRAPH ?g {
     BIND (<http://contactPointUri> AS ?s) 
-    ?s a <http://schema.org/ContactPoint> ; 
+    ?s a <http://schema.org/ContactPoint> ;
       <http://schema.org/telephone> ?o . 
   } 
 } 
-; 
+;
 DELETE { 
   GRAPH ?g { ?s <http://xmlns.com/foaf/0.1/page> ?o . } 
 } 
@@ -391,7 +391,7 @@ WHERE {
   VALUES ?g { <http://mu.semte.ch/graphs/administrative-unit> <http://mu.semte.ch/graphs/worship-service> } 
   GRAPH ?g {
     BIND (<http://contactPointUri> AS ?s) 
-    ?s a <http://schema.org/ContactPoint> ; 
+    ?s a <http://schema.org/ContactPoint> ;
       <http://xmlns.com/foaf/0.1/page> ?o . 
   } 
 } 
@@ -405,11 +405,11 @@ WHERE {
     VALUES ?g { <http://mu.semte.ch/graphs/administrative-unit> <http://mu.semte.ch/graphs/worship-service> } 
     GRAPH ?g {
         BIND (<http://kboOrgUri> AS ?s) 
-        ?s a <http://mu.semte.ch/vocabularies/ext/KboOrganisatie> ; 
+        ?s a <http://mu.semte.ch/vocabularies/ext/KboOrganisatie> ;
             <http://mu.semte.ch/vocabularies/ext/rechtsvorm> ?o . 
     } 
 } 
-; 
+;
 DELETE { 
     GRAPH ?g { ?s <http://www.w3.org/2004/02/skos/core#altLabel> ?o . } 
 } 
@@ -417,11 +417,11 @@ WHERE {
     VALUES ?g { <http://mu.semte.ch/graphs/administrative-unit> <http://mu.semte.ch/graphs/worship-service> } 
     GRAPH ?g {
             BIND (<http://kboOrgUri> AS ?s) 
-        ?s a <http://mu.semte.ch/vocabularies/ext/KboOrganisatie> ; 
+        ?s a <http://mu.semte.ch/vocabularies/ext/KboOrganisatie> ;
             <http://www.w3.org/2004/02/skos/core#altLabel> ?o . 
     } 
 } 
-; 
+;
 DELETE { 
     GRAPH ?g { ?s <http://mu.semte.ch/vocabularies/ext/startDate> ?o . } 
 } 
@@ -429,11 +429,11 @@ WHERE {
     VALUES ?g { <http://mu.semte.ch/graphs/administrative-unit> <http://mu.semte.ch/graphs/worship-service> } 
     GRAPH ?g {
         BIND (<http://kboOrgUri> AS ?s) 
-        ?s a <http://mu.semte.ch/vocabularies/ext/KboOrganisatie> ; 
+        ?s a <http://mu.semte.ch/vocabularies/ext/KboOrganisatie> ;
             <http://mu.semte.ch/vocabularies/ext/startDate> ?o . 
     } 
 } 
-; 
+;
 DELETE { 
     GRAPH ?g { ?s <http://www.w3.org/ns/regorg#legalName> ?o . } 
 } 
@@ -441,11 +441,11 @@ WHERE {
     VALUES ?g { <http://mu.semte.ch/graphs/administrative-unit> <http://mu.semte.ch/graphs/worship-service> } 
     GRAPH ?g {
         BIND (<http://kboOrgUri> AS ?s) 
-        ?s a <http://mu.semte.ch/vocabularies/ext/KboOrganisatie> ; 
+        ?s a <http://mu.semte.ch/vocabularies/ext/KboOrganisatie> ;
             <http://www.w3.org/ns/regorg#legalName> ?o . 
     } 
 } 
-; 
+;
 DELETE { 
     GRAPH ?g { ?s <http://purl.org/dc/terms/modified> ?o . } 
 } 
@@ -453,11 +453,11 @@ WHERE {
     VALUES ?g { <http://mu.semte.ch/graphs/administrative-unit> <http://mu.semte.ch/graphs/worship-service> } 
     GRAPH ?g {
         BIND (<http://kboOrgUri> AS ?s) 
-        ?s a <http://mu.semte.ch/vocabularies/ext/KboOrganisatie> ; 
+        ?s a <http://mu.semte.ch/vocabularies/ext/KboOrganisatie> ;
             <http://purl.org/dc/terms/modified> ?o . 
     } 
 } 
-; 
+;
 DELETE { 
     GRAPH ?g { ?s <http://www.w3.org/ns/regorg#orgStatus> ?o . } 
 } 
@@ -465,7 +465,7 @@ WHERE {
     VALUES ?g { <http://mu.semte.ch/graphs/administrative-unit> <http://mu.semte.ch/graphs/worship-service> } 
     GRAPH ?g {
         BIND (<http://kboOrgUri> AS ?s) 
-        ?s a <http://mu.semte.ch/vocabularies/ext/KboOrganisatie> ; 
+        ?s a <http://mu.semte.ch/vocabularies/ext/KboOrganisatie> ;
             <http://www.w3.org/ns/regorg#orgStatus> ?o . 
     } 
 } 

--- a/test/lib/queries.test.js
+++ b/test/lib/queries.test.js
@@ -43,6 +43,9 @@ const {
       sparqlEscapeString: (str) => {
         return `"""${str}"""`;
       },
+      sparqlEscapeDate: (date) => {
+        return `"${date}"^^xsd:date`;
+      },
     },
     "@lblod/mu-auth-sudo": {
       querySudo: querySudoStub,
@@ -146,7 +149,7 @@ describe("Queries", () => {
           formalName: "formalName",
           shortName: "shortName",
           changeTime: "2024-01-01",
-          activeState: "activeState",
+          activeState: "http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6",
         }
       );
       assert.strictEqual(normalize(result), normalize(buildKboOrgQueryFull));
@@ -172,6 +175,7 @@ describe("Queries", () => {
         "http://mu.semte.ch/vocabularies/ext/KboOrganisatie",
         "http://purl.org/dc/terms/modified",
         "2024-01-01",
+        "date",
         "<http://mu.semte.ch/graphs/administrative-unit>"
       );
 
@@ -183,6 +187,7 @@ describe("Queries", () => {
         "http://mu.semte.ch/vocabularies/ext/KboOrganisatie",
         "http://purl.org/dc/terms/modified",
         undefined,
+        "date",
         "<http://mu.semte.ch/graphs/administrative-unit>"
       );
 
@@ -200,7 +205,7 @@ describe("Queries", () => {
           kboNumber: "0207437468",
           formalName: "Stad Aalst",
           startDate: "1968-01-01",
-          activeState: "active",
+          activeState: "http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6",
           rechtsvorm: "Stad/Gemeente",
           email: "info@aalst.be",
           phone: "053 77 93 00",

--- a/test/lib/queries.test.js
+++ b/test/lib/queries.test.js
@@ -24,6 +24,7 @@ const updateSudoStub = sinon.stub();
 
 // Stub `mu-auth-sudo` module and `mu` module part of `mu-semtech/mu-javascript-template` microservice
 const {
+  dataValueType,
   buildKboAddressQuery,
   buildContactPointQuery,
   buildKboIdentifierQuery,
@@ -171,24 +172,24 @@ describe("Queries", () => {
   describe("buildUpdateQuery", () => {
     it("should return the correct query", () => {
       const result = buildUpdateQuery(
+        "<http://mu.semte.ch/graphs/administrative-unit>",
         "http://kboOrgUri",
         "http://mu.semte.ch/vocabularies/ext/KboOrganisatie",
         "http://purl.org/dc/terms/modified",
         "2024-01-01",
-        "date",
-        "<http://mu.semte.ch/graphs/administrative-unit>"
+        dataValueType.DATE
       );
 
       assert.strictEqual(normalize(result), normalize(buildUpdateQueryFull));
     });
     it("should return the correct query when object is undefined", () => {
       const result = buildUpdateQuery(
+        "<http://mu.semte.ch/graphs/administrative-unit>",
         "http://kboOrgUri",
         "http://mu.semte.ch/vocabularies/ext/KboOrganisatie",
         "http://purl.org/dc/terms/modified",
         undefined,
-        "date",
-        "<http://mu.semte.ch/graphs/administrative-unit>"
+        dataValueType.DATE
       );
 
       assert.strictEqual(normalize(result), normalize(buildUpdateQueryDefault));


### PR DESCRIPTION
# Context

[OP-3584]

To be tested with https://github.com/lblod/app-organization-portal/pull/537

Values fetched from wegwijs were always stored as string, but they can actually have other types as well (here date and uri). This PR adds the correct data type when updating the db.

## Side quests

1. I also bumped some dev dependencies, something was off and was preventing the service to start
2. I updated the tests accordingly as well

# How to test

Please refer to https://github.com/lblod/app-organization-portal/pull/537 and its changelog for test instructions :)