### PR TITLE
OP-3560 Fix KBO organizations' date formats

### DIFF
--- a/lib/queries.js
+++ b/lib/queries.js
@@ -1,4 +1,4 @@
-import { uuid, sparqlEscapeUri, sparqlEscapeString, sparqlEscapeDate } from "mu";
+import { uuid, sparqlEscapeUri, sparqlEscapeString, sparqlEscapeDate, sparqlEscapeDateTime} from "mu";
 import { querySudo as query, updateSudo as update } from "@lblod/mu-auth-sudo";
 
 const graphs = [
@@ -12,6 +12,7 @@ export const dataValueType = {
   STRING: sparqlEscapeString,
   DATE: sparqlEscapeDate,
   URI: sparqlEscapeUri,
+  DATETIME: sparqlEscapeDateTime,
 }
 
 /**
@@ -482,7 +483,7 @@ export const buildKboOrgQuery = (
     )} `;
   }
   if (kboFields.startDate) {
-    kboOrgStr += `; <http://mu.semte.ch/vocabularies/ext/startDate> ${sparqlEscapeDate(
+    kboOrgStr += `; <http://mu.semte.ch/vocabularies/ext/startDate> ${sparqlEscapeDateTime(
       kboFields.startDate
     )} `;
   }
@@ -497,7 +498,7 @@ export const buildKboOrgQuery = (
     )} `;
   }
   if (kboFields.changeTime) {
-    kboOrgStr += `; <http://purl.org/dc/terms/modified> ${sparqlEscapeDate(
+    kboOrgStr += `; <http://purl.org/dc/terms/modified> ${sparqlEscapeDateTime(
       kboFields.changeTime
     )} `;
   }
@@ -732,7 +733,7 @@ const updateKboOrganization = async (kboOrgUri, kboFields) => {
     "http://mu.semte.ch/vocabularies/ext/KboOrganisatie",
     "http://mu.semte.ch/vocabularies/ext/startDate",
     kboFields.startDate,
-    dataValueType.DATE
+    dataValueType.DATETIME
   );
 
   const updateFormalNameQuery = buildUpdateQuery(
@@ -749,7 +750,7 @@ const updateKboOrganization = async (kboOrgUri, kboFields) => {
     "http://mu.semte.ch/vocabularies/ext/KboOrganisatie",
     "http://purl.org/dc/terms/modified",
     kboFields.changeTime,
-    dataValueType.DATE
+    dataValueType.DATETIME
   );
 
   const updateActiveStateQuery = buildUpdateQuery(

--- a/lib/queries.js
+++ b/lib/queries.js
@@ -1,4 +1,4 @@
-import { uuid, sparqlEscapeUri, sparqlEscapeString, sparqlEscapeDate, sparqlEscapeDateTime} from "mu";
+import { uuid, sparqlEscapeUri, sparqlEscapeString, sparqlEscapeDateTime} from "mu";
 import { querySudo as query, updateSudo as update } from "@lblod/mu-auth-sudo";
 
 const graphs = [
@@ -10,7 +10,6 @@ const graphValues = graphs.map((graph) => sparqlEscapeUri(graph)).join(" ");
 
 export const dataValueType = {
   STRING: sparqlEscapeString,
-  DATE: sparqlEscapeDate,
   URI: sparqlEscapeUri,
   DATETIME: sparqlEscapeDateTime,
 }

--- a/test/lib/queries.data.js
+++ b/test/lib/queries.data.js
@@ -52,10 +52,10 @@ export const buildKboOrgQueryFull = `
     <http://schema.org/contactPoint> <http://contactPointUri> ;
     <http://www.w3.org/ns/adms#identifier> <http://kboIdentifierUri> ;
     <http://mu.semte.ch/vocabularies/ext/rechtsvorm> """Stad / gemeente""" ;
-    <http://mu.semte.ch/vocabularies/ext/startDate> "1968-01-01"^^xsd:date ;
+    <http://mu.semte.ch/vocabularies/ext/startDate> "1968-01-01T00:00:00"^^xsd:dateTime ;
     <http://www.w3.org/ns/regorg#legalName> """formalName""" ;
     <http://www.w3.org/2004/02/skos/core#altLabel> """shortName""" ;
-    <http://purl.org/dc/terms/modified> "2024-01-01"^^xsd:date ;
+    <http://purl.org/dc/terms/modified> "2024-01-01T00:00:00"^^xsd:dateTime ;
     <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
 `;
 
@@ -85,7 +85,7 @@ WHERE {
 ;
 INSERT { 
   GRAPH ?g { 
-    ?s <http://purl.org/dc/terms/modified> "2024-01-01"^^xsd:date . 
+    ?s <http://purl.org/dc/terms/modified> "2024-01-01T00:00:00"^^xsd:dateTime . 
   } 
 } 
 WHERE { 
@@ -267,7 +267,7 @@ WHERE {
 } 
 ;
 INSERT { 
-    GRAPH ?g { ?s <http://mu.semte.ch/vocabularies/ext/startDate> "1968-01-01"^^xsd:date . } 
+    GRAPH ?g { ?s <http://mu.semte.ch/vocabularies/ext/startDate> "1968-01-01T00:00:00"^^xsd:dateTime . } 
 } 
 WHERE { 
     VALUES ?g { <http://mu.semte.ch/graphs/administrative-unit> <http://mu.semte.ch/graphs/worship-service> } 
@@ -313,7 +313,7 @@ WHERE {
 } 
 ;
 INSERT { 
-    GRAPH ?g { ?s <http://purl.org/dc/terms/modified> "2023-11-15"^^xsd:date . } 
+    GRAPH ?g { ?s <http://purl.org/dc/terms/modified> "2023-11-15T00:00:00"^^xsd:dateTime . } 
 } 
 WHERE { 
     VALUES ?g { <http://mu.semte.ch/graphs/administrative-unit> <http://mu.semte.ch/graphs/worship-service> } 

--- a/test/lib/queries.test.js
+++ b/test/lib/queries.test.js
@@ -146,10 +146,10 @@ describe("Queries", () => {
         "http://abbOrgUri",
         {
           rechtsvorm: "Stad / gemeente",
-          startDate: "1968-01-01",
+          startDate: "1968-01-01T00:00:00",
           formalName: "formalName",
           shortName: "shortName",
-          changeTime: "2024-01-01",
+          changeTime: "2024-01-01T00:00:00",
           activeState: "http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6",
         }
       );
@@ -205,7 +205,7 @@ describe("Queries", () => {
           ovoNumber: "OVO001992",
           kboNumber: "0207437468",
           formalName: "Stad Aalst",
-          startDate: "1968-01-01",
+          startDate: "1968-01-01T00:00:00",
           activeState: "http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6",
           rechtsvorm: "Stad/Gemeente",
           email: "info@aalst.be",

--- a/test/lib/queries.test.js
+++ b/test/lib/queries.test.js
@@ -200,7 +200,7 @@ describe("Queries", () => {
     it("should return the correct query", async () => {
       await updateKboOrg(
         {
-          changeTime: "2023-11-15",
+          changeTime: "2023-11-15T00:00:00",
           shortName: "Aalst",
           ovoNumber: "OVO001992",
           kboNumber: "0207437468",

--- a/test/lib/queries.test.js
+++ b/test/lib/queries.test.js
@@ -44,8 +44,8 @@ const {
       sparqlEscapeString: (str) => {
         return `"""${str}"""`;
       },
-      sparqlEscapeDate: (date) => {
-        return `"${date}"^^xsd:date`;
+      sparqlEscapeDateTime: (dateTime) => {
+        return `"${dateTime}"^^xsd:dateTime`;
       },
     },
     "@lblod/mu-auth-sudo": {
@@ -176,8 +176,8 @@ describe("Queries", () => {
         "http://kboOrgUri",
         "http://mu.semte.ch/vocabularies/ext/KboOrganisatie",
         "http://purl.org/dc/terms/modified",
-        "2024-01-01",
-        dataValueType.DATE
+        "2024-01-01T00:00:00",
+        dataValueType.DATETIME
       );
 
       assert.strictEqual(normalize(result), normalize(buildUpdateQueryFull));
@@ -189,7 +189,7 @@ describe("Queries", () => {
         "http://mu.semte.ch/vocabularies/ext/KboOrganisatie",
         "http://purl.org/dc/terms/modified",
         undefined,
-        dataValueType.DATE
+        dataValueType.DATETIME
       );
 
       assert.strictEqual(normalize(result), normalize(buildUpdateQueryDefault));


### PR DESCRIPTION
- Changed Date to DateTime
- Updated the tests accordingly

### Ticket 
[OP-3560]

### Testing
1. Find a kbo organisation
2. Delete the modified/startDate and add an old modified date to trick the service into thinking it needs to refresh
3. Run either `drc exec kbo-data-sync curl -X POST http://localhost/sync-all-kbo-data` to trigger a complete healing or `drc exec kbo-data-sync curl -X POST http://localhost/sync-kbo-data/{STRUCTURED_IDENTIFICATOR_INSTANCE}` to only heal for your chosen instance. It should then make it a dateTime