### PR TITLE
OP-3765: edit to updateOvoNumberAndUri to make it work with organizat…

### DIFF
--- a/lib/queries.js
+++ b/lib/queries.js
@@ -233,7 +233,8 @@ export async function updateOvoNumberAndUri(
         )} a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> .
 
         ?abbOrg <http://www.w3.org/ns/adms#identifier>/<https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>
-                    <http://data.lblod.info/id/gestructureerdeIdentificatoren/9d8f0761-0366-11f1-b806-e792b3ec0a3f> .
+                    ${sparqlEscapeUri(ovoStructuredIdUri)} .
+
         OPTIONAL {
           ?abbOrg <http://www.w3.org/2002/07/owl#sameAs> ?ovoUri .
         }

--- a/lib/queries.js
+++ b/lib/queries.js
@@ -232,11 +232,10 @@ export async function updateOvoNumberAndUri(
           ovoStructuredIdUri
         )} a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> .
 
+        ?abbOrg <http://www.w3.org/ns/adms#identifier>/<https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>
+                    <http://data.lblod.info/id/gestructureerdeIdentificatoren/9d8f0761-0366-11f1-b806-e792b3ec0a3f> .
         OPTIONAL {
-          ?abbOrg <http://www.w3.org/ns/adms#identifier>/<https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator> ${sparqlEscapeUri(
-            ovoStructuredIdUri
-          )} ;
-          <http://www.w3.org/2002/07/owl#sameAs> ?ovoUri .
+          ?abbOrg <http://www.w3.org/2002/07/owl#sameAs> ?ovoUri .
         }
 
         OPTIONAL { ${sparqlEscapeUri(


### PR DESCRIPTION
- Edit to updateOvoNumberAndUri to make it work with organizations that have no owl:sameAs in OP data. The old implementation led to ?abbOrg being unbound if this is the case, which led to no updates from wegwijs.

TO TEST:
- rysnc with prod OP data.
-  build this image locally and add to OP docker-compose.override.yml:
```
services:
  kbo-data-sync:
    image: local/sync-wegwijs
    environment:
      CRON_PATTERN: "*/5 * * * *"
```
- run OP stack.
- check service logs to see that healing finished.
- check that the OVO code for AGB Lokeren is added via frontend.